### PR TITLE
Fix the weird behavieur after selecting a small cabin

### DIFF
--- a/.vscode/robigo.py
+++ b/.vscode/robigo.py
@@ -205,11 +205,13 @@ if __name__ == '__main__':
                                             if t == 0: # first enumerate
                                                 session.sendKey('space')
                                                 session.sendDelay(1)
+                                                session.sleep(1)
                                             else:
                                                 session.sendKey('UI_Up')
                                                 session.sendDelay(1)
                                                 session.sendKey('space')
                                                 session.sendDelay(1)
+                                                session.sleep(1)
                                         else:
                                             break
                                 else: # high-value


### PR DESCRIPTION
When a small cabin is selected the loop has no time to refresh the image. Adding a small sleep will slow a bit the process of selecting cabin but will give enought time to refresh correctly and avoid poping up the mission filters. [Fixed isue](https://github.com/Matrixchung/EDAutopilot/issues/11)