### PR TITLE
Repair and stock

### DIFF
--- a/.vscode/robigo.py
+++ b/.vscode/robigo.py
@@ -618,12 +618,12 @@ if __name__ == '__main__':
                         # Repair
                         session.sendKey('UI_Right')
                         session.sendDelay(1, block=True)
-                        session.sendKey('space')  # force refuel
+                        session.sendKey('space')  # force repair
                         session.sendDelay(1, block=True)
                         # Restock
                         session.sendKey('UI_Right')
                         session.sendDelay(1, block=True)
-                        session.sendKey('space')  # force refuel
+                        session.sendKey('space')  # force stock
                         session.sendDelay(1, block=True)
 
                         session.sendKey('UI_Down')

--- a/.vscode/robigo.py
+++ b/.vscode/robigo.py
@@ -95,7 +95,7 @@ if __name__ == '__main__':
     firstJumpDest = 'Wredguia TH-U c16-18' # From Robigo to Sothis (3-jump middle star)
     thirdJumpDest = 'Wredguia TH-U c16-18' # From Sothis to Robigo (3-jump middle star)
     maxMissionCount = 8
-    missionCountOverride = 0 # For any unread missions or the mission count not shown properly
+    missionCountOverride = 8 # For any unread missions or the mission count not shown properly
     ## USER_DEFINITIONS_AREA_ENDS
 
     states = ['initial','get-mission','mission-received','select-target-sothis','undock','thrust-up','first-align','first-jump', # in Robigo
@@ -611,14 +611,25 @@ if __name__ == '__main__':
                         # if isImageInGame(button_fuel,confidence=0.6): # Fuel Button
                             #session.sendKey('space')
                             #session.sendDelay(3,block=True)
-                        session.sendKey('space') # force refuel
-                        session.sendDelay(4,block=True)
-                        session.sendKey('space') # force refuel
-                        session.sendDelay(1,block=True)
+                        session.sendKey('space')  # force refuel
+                        session.sendDelay(4, block=True)
+                        session.sendKey('space')  # force refuel
+                        session.sendDelay(1, block=True)
+                        # Repair
+                        session.sendKey('UI_Right')
+                        session.sendDelay(1, block=True)
+                        session.sendKey('space')  # force refuel
+                        session.sendDelay(1, block=True)
+                        # Restock
+                        session.sendKey('UI_Right')
+                        session.sendDelay(1, block=True)
+                        session.sendKey('space')  # force refuel
+                        session.sendDelay(1, block=True)
+
                         session.sendKey('UI_Down')
-                        session.sendDelay(2,block=True)
-                        session.sendKey('space') # auto fuel and go to Station Services
-                        session.sendDelay(5,block=True) 
+                        session.sendDelay(2, block=True)
+                        session.sendKey('space')  # auto fuel and go to Station Services
+                        session.sendDelay(5, block=True)
                     if session.guiFocus == 'StationServices':
                         session.sleep(2)
                         mouseClick(getAbsoluteCoordByOffset(windowCoord,offset_button_passenger))

--- a/.vscode/robigo.py
+++ b/.vscode/robigo.py
@@ -95,7 +95,7 @@ if __name__ == '__main__':
     firstJumpDest = 'Wredguia TH-U c16-18' # From Robigo to Sothis (3-jump middle star)
     thirdJumpDest = 'Wredguia TH-U c16-18' # From Sothis to Robigo (3-jump middle star)
     maxMissionCount = 8
-    missionCountOverride = 8 # For any unread missions or the mission count not shown properly
+    missionCountOverride = 0 # For any unread missions or the mission count not shown properly
     ## USER_DEFINITIONS_AREA_ENDS
 
     states = ['initial','get-mission','mission-received','select-target-sothis','undock','thrust-up','first-align','first-jump', # in Robigo


### PR DESCRIPTION
I found necessary to repair sometimes as the nav beacon can be hit..

Also there is a [known bug in ED](https://www.reddit.com/r/EliteDangerous/comments/inz4z8/help_game_crashing_when_i_try_to_replenish/) with the passenger cabins. If the cabin needs to be replenish, if you do it through the passenger missions menu (the bot will trigger it trying to select the cabin for the mission) the game will crash. To avoid this you can use the option stock while docked in the main menu